### PR TITLE
Updating `.track` to support Promises for async

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "./src/core.js",
   "dependencies": {
     "MD5": "^1.3.0",
-    "request": "^2.72.0"
+    "bluebird": "^3.4.7",
+    "request-promise": "^4.1.1"
   },
   "devDependencies": {
     "gulp": "3.9.0",
@@ -13,5 +14,10 @@
     "rimraf": "~2.2.8",
     "uglifyify": "^3.0.2",
     "vinyl-source-stream": "^1.0.0"
+  },
+  "eslintConfig": {
+    "rules": {
+      "indent": 0
+    }
   }
 }

--- a/src/event.js
+++ b/src/event.js
@@ -1,4 +1,5 @@
-var Request = require('request'),
+var Request = require('request-promise'),
+    BPromise = require('bluebird'),
     Enums = require('./enums'),
     Constants = require('./constants'),
     _ = require('./utils');
@@ -34,9 +35,9 @@ _.extend(VoiceEvent.prototype, {
 
     var URL = Constants.authURL(Constants.api.baseURL + Constants.api.eventsAPI, this.data.app_token);
 
-    return Request.post(URL, { timeout: 1500, json: this.data }, function(error, response, body){
+    return BPromise.resolve(Request.post(URL, { timeout: 1500, json: this.data })).then(function(error, response, body) {
 
-      var status = response ? response.statusCode : 500
+      var status = response ? response.statusCode : 500,
           output = {
             status: status
           };
@@ -44,15 +45,11 @@ _.extend(VoiceEvent.prototype, {
       if(!error && status >= 200 && status < 300 || status === 304){
         output.response = body;
 
-        if(_.isFunction(cb)){
-          cb(null, output);
-        }
+        return output;
       }else{
-        if(_.isFunction(cb)){
-          cb(error, output);
-        }
+        throw error;
       }
-    });
+    }).asCallback(cb);
   }
 });
 


### PR DESCRIPTION
Now, `VoiceInsights.track` will return a promise. You may still pass a
callback to `.track`.

This should not change current functionality in any way, but it does allow you to use Promises in implementations for synchronization when using `.track`.